### PR TITLE
Feature/notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/bower_components
 package
 app/scripts
 .idea/
+.vscode/

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -16,6 +16,7 @@
     "default_popup": "popup.html"
   },
   "default_locale": "en",
+  "options_page": "options.html",
   "background": {
     "scripts": [
       "scripts/chromereload.js",
@@ -24,6 +25,7 @@
   },
   "permissions": [
     "tabs",
-    "notifications"
+    "notifications",
+    "storage"
   ]
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -23,6 +23,7 @@
     ]
   },
   "permissions": [
-    "tabs"
+    "tabs",
+    "notifications"
   ]
 }

--- a/app/options.html
+++ b/app/options.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <style>
+		@font-face {
+		  font-family: Vazir;
+		  src: url('fonts/Vazir.eot');
+		  src: url('fonts/Vazir.eot?#iefix') format('embedded-opentype'),
+		       url('fonts/Vazir.woff') format('woff'),
+		       url('fonts/Vazir.ttf') format('truetype');
+		  font-weight: normal;
+		}
+
+    body {
+      margin: 0;
+      padding: 0;
+      background: #f2f2f2;
+			font-family: "Vazir", "Tahoma", sans-serif;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 800px;
+      margin: 100px auto 50px;
+    }
+
+    #logo {
+      width: 100%;
+      height: 96px;
+      margin: 100px 0px 50px;
+      text-align: center;
+    }
+
+    #logo img {
+      width: 96px;
+    }
+
+    .row {
+      width: 100%;
+      clear:both;
+      overflow: auto;
+      zoom: 1;
+      direction: rtl;
+      padding: 25px 0px;
+    }
+
+    .row.disabled {
+      display: none;
+    }
+
+    .row .label {
+      width: 50%;
+      font-size: 20px;
+      line-height: 2em;
+      float: right;
+      text-align: left;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      padding: 0px 20px;
+      border-left: 1px #ddd solid;
+    }
+
+    .row .label .description {
+      display: block;
+      font-size: 14px;
+      line-height: 1.4em;
+      color: #999999;
+    }
+
+    .row .label .description .warning {
+      background: #FDFBD2;
+      color: #ADA505;
+      display: block;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      padding: 10px;
+      border-radius: 6px;
+      margin-top: 10px;
+    }
+
+    #successMessage {
+      background: #E0F6D9;
+      color: #2D7019;
+      display: block;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      padding: 12px 30px;
+      border-radius: 6px;
+      opacity: 0;
+      position: absolute;
+      right: 20px;
+      top: 20px;
+      border: 1px #B0E99F solid;
+      transition: all .2s linear;
+      font-size: 16px;
+    }
+
+    #successMessage.visible {
+      opacity: 1;
+    }
+
+    .row .input {
+      font-size: 20px;
+      line-height: 2em;
+      width: 45%;
+      float: left;
+    }
+
+    .row .input input, .row .input select {
+      font-size: 14px;
+      line-height: 1.5em;
+			font-family: "Vazir", "Tahoma", sans-serif;
+    }
+
+    .row .input #submit {
+      background: #57D131;
+      border: none;
+      padding: 10px 15px;
+      border-radius: 6px;
+      color: #FFFFFF;
+      cursor: pointer;
+      transition: all .2s linear;
+    }
+
+    .row .input #submit:hover {
+      opacity: 0.7;
+    }
+  </style>
+  <script src="scripts/options.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div id="logo">
+      <img src="images/icon_128.png" alt="">
+    </div> <!-- #logo -->
+    
+    <div class="row">
+      <div class="label">
+        نمایش خودکار اعلان
+        <div class="description">
+          با فعال‌سازی این گزینه، به محض ورود به صفحات شاپرک، به طور خودکار یک اعلان دریافت خواهید کرد. 
+          <span class="warning">
+            در صورتی که کاربر سیستم‌عامل مک هستید توجه داشته باشید
+            که در صورت اجرای گوگل‌کروم به صورت تمام صفحه، اعلانات نمایش داده نخواهند شد.
+          </span>
+        </div> <!-- .description -->
+      </div> <!-- .label -->
+
+      <div class="input">
+        <input class="option" type="checkbox" name="automaticNotification" id="automaticNotification">
+      </div> <!-- .input -->
+    </div> <!-- .row -->
+
+    <div class="row" id="automaticNotificationDurationWrapper">
+      <div class="label">
+        مدت‌زمان نمایش اعلان
+      </div> <!-- .label -->
+
+      <div class="input">
+        <select class="option" name="automaticNotificationDuration" id="automaticNotificationDuration">
+          <option value="2" selected>کوتاه (۲ثانیه)</option>
+          <option value="5">عادی (۵ثانیه)</option>
+          <option value="10">طولانی (۱۰ثانیه)</option>
+        </select>
+      </div> <!-- .input -->
+    </div> <!-- .row -->
+
+  </div> <!-- .container -->
+
+  <div id="successMessage">
+    تنظیمات با موفقیت ذخیره شد
+  </div>
+</body>
+</html>

--- a/app/scripts.babel/background.js
+++ b/app/scripts.babel/background.js
@@ -1,21 +1,21 @@
 'use strict';
 
-chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-    chrome.tabs.query({
-        active: true,
-        url: "https://*.shaparak.ir/*"
-    }, tabs => {
-    	const tab = tabs[0];
-        chrome.pageAction.show(tab.id);
-        chrome.pageAction.setIcon({
-        	tabId: tab.id,
-        	path: {
-        		"128": "images/verified_icon_128.png"
-        	}
-        });
-        chrome.pageAction.setTitle({
-        	tabId: tab.id,
-        	title: chrome.i18n.getMessage("verified")
-        })
+chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+  chrome.tabs.query({
+    active: true,
+    url: "https://*.shaparak.ir/*"
+  }, tabs => {
+    const tab = tabs[0];
+    chrome.pageAction.show(tab.id);
+    chrome.pageAction.setIcon({
+      tabId: tab.id,
+      path: {
+        "128": "images/verified_icon_128.png"
+      }
     });
+    chrome.pageAction.setTitle({
+      tabId: tab.id,
+      title: chrome.i18n.getMessage("verified")
+    });
+  });
 });

--- a/app/scripts.babel/background.js
+++ b/app/scripts.babel/background.js
@@ -1,21 +1,60 @@
 'use strict';
-
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   chrome.tabs.query({
     active: true,
-    url: "https://*.shaparak.ir/*"
+    url: 'https://*.shaparak.ir/*'
   }, tabs => {
     const tab = tabs[0];
-    chrome.pageAction.show(tab.id);
-    chrome.pageAction.setIcon({
-      tabId: tab.id,
-      path: {
-        "128": "images/verified_icon_128.png"
-      }
-    });
-    chrome.pageAction.setTitle({
-      tabId: tab.id,
-      title: chrome.i18n.getMessage("verified")
-    });
+    
+    if (typeof tab !== 'undefined') {
+      const showNotification = (duration) => {
+        const message = {
+          iconUrl: 'images/verified_icon_128.png',
+          type: 'basic',
+          title: 'سایت معتبر است',
+          message: 'با خیال راحت پرداخت خود را انجام دهید',
+          priority: 1
+        };
+
+        // create unique notification id, this method creates different id for each transaction        
+        const notificationId = `${tab.id}|${tab.url}`;
+
+        chrome.notifications.create(notificationId, message, function () {
+          if (chrome.runtime.lastError) console.log(chrome.runtime.lastError.message);
+
+          // automatically hide the notification after 5 seconds
+          setTimeout(() => {
+            chrome.notifications.clear(notificationId, () => { });
+          }, duration * 1000);
+        });
+
+        chrome.notifications.onClicked.addListener(id => {
+          // hide notification on user click
+          if (id === notificationId) chrome.notifications.clear(notificationId, () => {});
+        });
+      };
+
+      const configurePopup = () => {
+        chrome.pageAction.show(tab.id);
+        chrome.pageAction.setIcon({
+          tabId: tab.id,
+          path: {
+            '128': 'images/verified_icon_128.png'
+          }
+        });
+        chrome.pageAction.setTitle({
+          tabId: tab.id,
+          title: chrome.i18n.getMessage('verified')
+        });
+      };
+
+      chrome.storage.sync.get({
+        automaticNotification: false,
+        automaticNotificationDuration: 2
+      }, (items) => {
+        if (items.automaticNotification) showNotification(items.automaticNotificationDuration);
+        configurePopup();
+      });
+    }
   });
 });

--- a/app/scripts.babel/options.js
+++ b/app/scripts.babel/options.js
@@ -1,0 +1,54 @@
+'use strict';
+
+window.addEventListener('load', () => {
+  const submitButton = document.getElementById('submit');
+  const automaticNotification = document.getElementById('automaticNotification');
+  const automaticNotificationDuration = document.getElementById('automaticNotificationDuration');
+  const automaticNotificationDurationWrapper = document.getElementById('automaticNotificationDurationWrapper');
+
+  // save user configrations and show proper message  
+  let timer;
+  const saveConfigurations = () => {
+    const showSuccessMessage = () => {
+      clearTimeout(timer);
+
+      // show success message when user configurations saved
+      const message = document.getElementById('successMessage');
+      message.classList.add('visible');
+
+      // automatically hide the message after 5 seconds
+      timer = setTimeout(() => {
+        message.classList.remove('visible');
+      }, 5000);
+    };
+
+    chrome.storage.sync.set({
+      automaticNotification: automaticNotification.checked,
+      automaticNotificationDuration: automaticNotificationDuration.value
+    }, showSuccessMessage);
+  };
+
+  // restore user configurations
+  chrome.storage.sync.get({
+    automaticNotification: false,
+    automaticNotificationDuration: 2
+  }, (items) => {
+    automaticNotification.checked = items.automaticNotification;
+    automaticNotificationDuration.value = items.automaticNotificationDuration;
+
+    const hideDuration = () => {
+      if (automaticNotification.checked === false) automaticNotificationDurationWrapper.classList.add('disabled')
+      else automaticNotificationDurationWrapper.classList.remove('disabled');
+    };
+    hideDuration();
+
+    automaticNotification.addEventListener('change', () => {
+      hideDuration();
+      saveConfigurations();
+    });
+
+    automaticNotificationDuration.addEventListener('change', () => {
+      saveConfigurations();
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds multiple changes to the extension to achieve "automatic notification" feature, the changes are listed below:
- Add an options page.
- A notification will be automatically displayed when you open up a  **shaprak.ir** sub domains, the functionality is disabled by default and can be enabled through options page.
- Add a couple of required permissions, `notifications` for displaying notifications and `storage` for saving and restoring user configurations(used in options page).
- Multiple minor changes in code style.
### Known issues
- MacOS users will not be able to see notifications when they are using Google Chrome in full screen mode, it's a known Google Chrome issue with MacOS.
- The notification displays again on the transaction success page, there should be a scenario  for preventing it but currently I have no idea for it and also it's not deal breaker so we can fix it in future versions.

Please let me know if there is any other issue.
